### PR TITLE
Add platform service scaffolding

### DIFF
--- a/MyApp.Android/MainActivity.cs
+++ b/MyApp.Android/MainActivity.cs
@@ -1,0 +1,24 @@
+using Android.App;
+using Android.Content.PM;
+using Android.OS;
+using MyApp;
+using MyApp.Android.Services;
+using MyApp.Services;
+
+namespace MyApp.Android;
+
+[Activity(Label = "MyApp", Theme = "@style/Theme.AppCompat.Light.NoActionBar", MainLauncher = true,
+    ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode |
+                           ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
+public class MainActivity : Activity
+{
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+
+        ServiceContainer.Register<INetworkConnectivity>(new AndroidNetworkConnectivity(this));
+        ServiceContainer.Register<IFileAccessService>(new AndroidFileAccessService(this));
+
+        AppStartup.ConfigureSharedServices();
+    }
+}

--- a/MyApp.Android/Properties/AndroidManifest.xml
+++ b/MyApp.Android/Properties/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.myapp.editor">
+  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="34" />
+  <application android:allowBackup="true"
+               android:icon="@mipmap/ic_launcher"
+               android:label="MyApp"
+               android:usesCleartextTraffic="false">
+    <uses-library android:name="org.apache.http.legacy" android:required="false" />
+  </application>
+
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+</manifest>

--- a/MyApp.Android/Services/AndroidFileAccessService.cs
+++ b/MyApp.Android/Services/AndroidFileAccessService.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Threading.Tasks;
+using Android.App;
+using Android.Content;
+using Android.Media;
+using Android.Provider;
+using MyApp.Services;
+
+namespace MyApp.Android.Services;
+
+public class AndroidFileAccessService : IFileAccessService
+{
+    private readonly Activity _activity;
+
+    public AndroidFileAccessService(Activity activity)
+    {
+        _activity = activity;
+    }
+
+    public Task<string?> PickOpenFileAsync(string[] mimeTypes)
+    {
+        var intent = new Intent(Intent.ActionOpenDocument);
+        intent.AddCategory(Intent.CategoryOpenable);
+        intent.SetType("*");
+        intent.PutExtra(Intent.ExtraMimeTypes, mimeTypes);
+
+        // In a real application you would use ActivityResult APIs.
+        return Task.FromResult<string?>(null);
+    }
+
+    public async Task SaveTextAsync(string filePath, string contents)
+    {
+        await File.WriteAllTextAsync(filePath, contents);
+        MediaScannerConnection.ScanFile(_activity, new[] { filePath }, null, null);
+    }
+}

--- a/MyApp.Android/Services/AndroidNetworkConnectivity.cs
+++ b/MyApp.Android/Services/AndroidNetworkConnectivity.cs
@@ -1,0 +1,29 @@
+using Android.Content;
+using Android.Net;
+using Android.Net.Wifi;
+using MyApp.Services;
+
+namespace MyApp.Android.Services;
+
+public class AndroidNetworkConnectivity : INetworkConnectivity
+{
+    private readonly ConnectivityManager _connectivityManager;
+
+    public AndroidNetworkConnectivity(Context context)
+    {
+        _connectivityManager = (ConnectivityManager)context.GetSystemService(Context.ConnectivityService)!;
+    }
+
+    public bool HasInternetAccess()
+    {
+        if (OperatingSystem.IsAndroidVersionAtLeast(23))
+        {
+            var capabilities = _connectivityManager.GetNetworkCapabilities(_connectivityManager.ActiveNetwork);
+            return capabilities?.HasCapability(NetCapability.Internet) == true &&
+                   capabilities?.HasCapability(NetCapability.Validated) == true;
+        }
+
+        var activeNetworkInfo = _connectivityManager.ActiveNetworkInfo;
+        return activeNetworkInfo?.IsConnected == true;
+    }
+}

--- a/MyApp.Skia.Gtk/Program.cs
+++ b/MyApp.Skia.Gtk/Program.cs
@@ -1,0 +1,74 @@
+using System;
+using Gtk;
+using MyApp;
+using MyApp.Commands;
+using MyApp.Services;
+
+namespace MyApp.Skia.Gtk;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        Application.Init();
+
+        ServiceContainer.Register<INetworkConnectivity>(new GtkNetworkStub());
+        ServiceContainer.Register<IFileAccessService>(new GtkFileAccessStub());
+        AppStartup.ConfigureSharedServices();
+
+        var window = new Window("MyApp")
+        {
+            DefaultWidth = 1024,
+            DefaultHeight = 768,
+            Resizable = true
+        };
+
+        var menuBar = BuildMenuBar();
+        var vbox = new VBox(false, 2);
+        vbox.PackStart(menuBar, false, false, 0);
+        window.Add(vbox);
+
+        window.DeleteEvent += (_, _) => CommandManager.Execute("Exit");
+
+        window.ShowAll();
+        Application.Run();
+    }
+
+    private static MenuBar BuildMenuBar()
+    {
+        var menuBar = new MenuBar();
+
+        var fileMenu = new Menu();
+        fileMenu.Append(CreateMenuItem("New", "NewDocument"));
+        fileMenu.Append(CreateMenuItem("Open", "OpenDocument"));
+        fileMenu.Append(CreateMenuItem("Save", "SaveDocument"));
+        fileMenu.Append(new SeparatorMenuItem());
+        fileMenu.Append(CreateMenuItem("Exit", "Exit"));
+
+        var root = new MenuItem("File") { Submenu = fileMenu };
+        menuBar.Append(root);
+
+        return menuBar;
+    }
+
+    private static MenuItem CreateMenuItem(string text, string commandName)
+    {
+        var item = new MenuItem(text);
+        item.Activated += (_, _) => CommandManager.Execute(commandName);
+        return item;
+    }
+
+    private class GtkNetworkStub : INetworkConnectivity
+    {
+        public bool HasInternetAccess() => true;
+    }
+
+    private class GtkFileAccessStub : IFileAccessService
+    {
+        public System.Threading.Tasks.Task<string?> PickOpenFileAsync(string[] mimeTypes) =>
+            System.Threading.Tasks.Task.FromResult<string?>(null);
+
+        public System.Threading.Tasks.Task SaveTextAsync(string filePath, string contents) =>
+            System.Threading.Tasks.Task.CompletedTask;
+    }
+}

--- a/MyApp.Windows/App.xaml.cs
+++ b/MyApp.Windows/App.xaml.cs
@@ -1,0 +1,21 @@
+using Microsoft.UI.Xaml;
+using MyApp;
+using MyApp.Services;
+using MyApp.Windows.Services;
+
+namespace MyApp.Windows;
+
+public partial class App : Application
+{
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        ServiceContainer.Register<INetworkConnectivity>(new WinUiNetworkConnectivity());
+        ServiceContainer.Register<IFileAccessService>(new WinUiFileAccessService());
+
+        AppStartup.ConfigureSharedServices();
+
+        var window = new MainWindow();
+        WindowHandleProvider.Initialize(window);
+        window.Activate();
+    }
+}

--- a/MyApp.Windows/MainWindow.cs
+++ b/MyApp.Windows/MainWindow.cs
@@ -1,0 +1,29 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MyApp.Commands;
+
+namespace MyApp.Windows;
+
+public class MainWindow : Window
+{
+    public MainWindow()
+    {
+        Title = "MyApp";
+        Width = 1024;
+        Height = 768;
+
+        var commandBar = new CommandBar();
+        commandBar.PrimaryCommands.Add(CreateAppBarButton("New", "NewDocument"));
+        commandBar.PrimaryCommands.Add(CreateAppBarButton("Open", "OpenDocument"));
+        commandBar.PrimaryCommands.Add(CreateAppBarButton("Save", "SaveDocument"));
+
+        Content = commandBar;
+    }
+
+    private static AppBarButton CreateAppBarButton(string label, string commandName)
+    {
+        var button = new AppBarButton { Label = label };
+        button.Click += (_, _) => CommandManager.Execute(commandName);
+        return button;
+    }
+}

--- a/MyApp.Windows/Services/WinUiFileAccessService.cs
+++ b/MyApp.Windows/Services/WinUiFileAccessService.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using System.Threading.Tasks;
+using MyApp.Services;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+
+namespace MyApp.Windows.Services;
+
+public class WinUiFileAccessService : IFileAccessService
+{
+    public async Task<string?> PickOpenFileAsync(string[] mimeTypes)
+    {
+        var picker = CreateOpenPicker(mimeTypes);
+        var file = await picker.PickSingleFileAsync();
+        return file?.Path;
+    }
+
+    public async Task SaveTextAsync(string filePath, string contents)
+    {
+        if (File.Exists(filePath))
+        {
+            var existing = await StorageFile.GetFileFromPathAsync(filePath);
+            await FileIO.WriteTextAsync(existing, contents);
+            return;
+        }
+
+        var picker = CreateSavePicker(Path.GetExtension(filePath));
+        var file = await picker.PickSaveFileAsync();
+        if (file is null)
+        {
+            return;
+        }
+
+        await FileIO.WriteTextAsync(file, contents);
+    }
+
+    private static FileOpenPicker CreateOpenPicker(string[] mimeTypes)
+    {
+        var picker = new FileOpenPicker();
+        picker.FileTypeFilter.Clear();
+        if (mimeTypes.Length == 0)
+        {
+            picker.FileTypeFilter.Add("*");
+        }
+        else
+        {
+            foreach (var mime in mimeTypes)
+            {
+                picker.FileTypeFilter.Add(mime);
+            }
+        }
+
+        InitializeWithWindow(picker);
+        return picker;
+    }
+
+    private static FileSavePicker CreateSavePicker(string? extension)
+    {
+        var picker = new FileSavePicker();
+        picker.FileTypeChoices.Add("Document", string.IsNullOrEmpty(extension) ? new[] { ".txt" } : new[] { extension });
+        InitializeWithWindow(picker);
+        return picker;
+    }
+
+    private static void InitializeWithWindow(object picker)
+    {
+        var handle = WindowHandleProvider.GetHandle();
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, handle);
+    }
+}

--- a/MyApp.Windows/Services/WinUiNetworkConnectivity.cs
+++ b/MyApp.Windows/Services/WinUiNetworkConnectivity.cs
@@ -1,0 +1,19 @@
+using System;
+using MyApp.Services;
+using Windows.Networking.Connectivity;
+
+namespace MyApp.Windows.Services;
+
+public class WinUiNetworkConnectivity : INetworkConnectivity
+{
+    public bool HasInternetAccess()
+    {
+        var profile = NetworkInformation.GetInternetConnectionProfile();
+        if (profile is null)
+        {
+            return false;
+        }
+
+        return profile.GetNetworkConnectivityLevel() == NetworkConnectivityLevel.InternetAccess;
+    }
+}

--- a/MyApp.Windows/WindowHandleProvider.cs
+++ b/MyApp.Windows/WindowHandleProvider.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.UI.Xaml;
+
+namespace MyApp.Windows;
+
+public static class WindowHandleProvider
+{
+    private static IntPtr _windowHandle;
+
+    public static void Initialize(Window window)
+    {
+        _windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(window);
+    }
+
+    public static IntPtr GetHandle()
+    {
+        if (_windowHandle == IntPtr.Zero)
+        {
+            throw new InvalidOperationException("Window handle has not been initialized.");
+        }
+
+        return _windowHandle;
+    }
+}

--- a/MyApp/AppStartup.cs
+++ b/MyApp/AppStartup.cs
@@ -1,0 +1,22 @@
+using System;
+using MyApp.Commands;
+using MyApp.Services;
+
+namespace MyApp;
+
+public static class AppStartup
+{
+    public static void ConfigureSharedServices()
+    {
+        CommandManager.Register("NewDocument", () => Console.WriteLine("New document requested"));
+        CommandManager.Register("OpenDocument", () => Console.WriteLine("Open document requested"));
+        CommandManager.Register("SaveDocument", () => Console.WriteLine("Save document requested"));
+        CommandManager.Register("Exit", () => Console.WriteLine("Exit requested"));
+    }
+
+    public static bool EnsureConnectivity()
+    {
+        var connectivity = ServiceContainer.Resolve<INetworkConnectivity>();
+        return connectivity.HasInternetAccess();
+    }
+}

--- a/MyApp/Commands/CommandManager.cs
+++ b/MyApp/Commands/CommandManager.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace MyApp.Commands;
+
+public static class CommandManager
+{
+    private static readonly ConcurrentDictionary<string, Action> _commands = new(StringComparer.OrdinalIgnoreCase);
+
+    public static void Register(string name, Action handler)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Command name must be provided.", nameof(name));
+        }
+
+        if (handler is null)
+        {
+            throw new ArgumentNullException(nameof(handler));
+        }
+
+        _commands[name] = handler;
+    }
+
+    public static bool Execute(string name)
+    {
+        if (name is null)
+        {
+            return false;
+        }
+
+        if (_commands.TryGetValue(name, out var handler))
+        {
+            handler();
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/MyApp/ServiceContainer.cs
+++ b/MyApp/ServiceContainer.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace MyApp;
+
+public static class ServiceContainer
+{
+    private static readonly ConcurrentDictionary<Type, object> _registrations = new();
+
+    public static void Register<TService>(TService implementation) where TService : class
+    {
+        if (implementation is null)
+        {
+            throw new ArgumentNullException(nameof(implementation));
+        }
+
+        _registrations[typeof(TService)] = implementation;
+    }
+
+    public static TService Resolve<TService>() where TService : class
+    {
+        if (_registrations.TryGetValue(typeof(TService), out var implementation))
+        {
+            return (TService)implementation;
+        }
+
+        throw new InvalidOperationException($"Service {typeof(TService).FullName} is not registered.");
+    }
+}

--- a/MyApp/Services/IFileAccessService.cs
+++ b/MyApp/Services/IFileAccessService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace MyApp.Services;
+
+public interface IFileAccessService
+{
+    Task<string?> PickOpenFileAsync(string[] mimeTypes);
+    Task SaveTextAsync(string filePath, string contents);
+}

--- a/MyApp/Services/INetworkConnectivity.cs
+++ b/MyApp/Services/INetworkConnectivity.cs
@@ -1,0 +1,6 @@
+namespace MyApp.Services;
+
+public interface INetworkConnectivity
+{
+    bool HasInternetAccess();
+}


### PR DESCRIPTION
## Summary
- add shared service abstractions and command wiring to support platform heads
- implement Android, GTK, and WinUI adapters that register platform services on startup
- configure Android manifest permissions and native menu integrations for desktop heads

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e1baced09c8331b144ef1c873535af