### PR TITLE
Fix MainPage initialization for DI

### DIFF
--- a/MyApp/MyApp/App.xaml
+++ b/MyApp/MyApp/App.xaml
@@ -2,9 +2,7 @@
 <Application
     x:Class="MyApp.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:views="using:MyApp.Views">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
-        <views:MainPage />
     </Application.Resources>
 </Application>

--- a/MyApp/MyApp/Views/MainPage.xaml.cs
+++ b/MyApp/MyApp/Views/MainPage.xaml.cs
@@ -16,5 +16,5 @@ public partial class MainPage
         DataContext = viewModel;
     }
 
-    public MainPageViewModel ViewModel { get; private set; } = null!;
+    public MainPageViewModel ViewModel { get; }
 }

--- a/MyApp/MyApp/Views/MainPage.xaml.cs
+++ b/MyApp/MyApp/Views/MainPage.xaml.cs
@@ -4,10 +4,17 @@ namespace MyApp.Views;
 
 public partial class MainPage
 {
-    public MainPage(MainPageViewModel viewModel)
+    public MainPage()
     {
-        ViewModel = viewModel;
+        InitializeComponent();
     }
 
-    public MainPageViewModel ViewModel { get; }
+    public MainPage(MainPageViewModel viewModel)
+        : this()
+    {
+        ViewModel = viewModel;
+        DataContext = viewModel;
+    }
+
+    public MainPageViewModel ViewModel { get; private set; } = null!;
 }


### PR DESCRIPTION
## Summary
- add a parameterless MainPage constructor that calls InitializeComponent and wires up the injected view model as the DataContext
- remove the implicit MainPage resource from App.xaml so the page is only constructed through the service provider

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d71a57788331918c5cf948ce2663