### PR TITLE
Configure shared project for Uno WinUI

### DIFF
--- a/MyApp/MyApp/App.xaml.cs
+++ b/MyApp/MyApp/App.xaml.cs
@@ -1,14 +1,16 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
 using MyApp.Services;
 using MyApp.ViewModels;
 using MyApp.Views;
 
 namespace MyApp;
 
-public partial class App
+public partial class App : Application
 {
     public App()
     {
+        InitializeComponent();
         Services = ConfigureServices();
         MainPage = Services.GetRequiredService<MainPage>();
     }

--- a/MyApp/MyApp/MyApp.csproj
+++ b/MyApp/MyApp/MyApp.csproj
@@ -1,11 +1,30 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <UseWinUI>true</UseWinUI>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="App.xaml" />
+    <None Remove="Views\MainPage.xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Page Include="Views\MainPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.230602000" />
+    <PackageReference Include="Uno.WinUI" Version="5.2.0" />
   </ItemGroup>
 </Project>

--- a/MyApp/MyApp/Views/MainPage.xaml.cs
+++ b/MyApp/MyApp/Views/MainPage.xaml.cs
@@ -1,12 +1,15 @@
+using Microsoft.UI.Xaml.Controls;
 using MyApp.ViewModels;
 
 namespace MyApp.Views;
 
-public partial class MainPage
+public sealed partial class MainPage : Page
 {
     public MainPage(MainPageViewModel viewModel)
     {
+        InitializeComponent();
         ViewModel = viewModel;
+        DataContext = viewModel;
     }
 
     public MainPageViewModel ViewModel { get; }


### PR DESCRIPTION
## Summary
- retarget the shared project to net8.0-windows10.0.19041.0 with Uno WinUI settings
- add Uno.WinUI and Windows App SDK package references and include shared XAML resources
- update App and MainPage code-behind to use WinUI types and initialize components

## Testing
- dotnet restore MyApp/MyApp.sln *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d7199ce883318f60afdda4e56e5c