### PR TITLE
Restore platform head project files and update solution

### DIFF
--- a/MyApp.Android/MyApp.Android.csproj
+++ b/MyApp.Android/MyApp.Android.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-android</TargetFramework>
+    <SupportedOSPlatformVersion>23</SupportedOSPlatformVersion>
+    <Nullable>enable</Nullable>
+    <ApplicationId>com.companyname.myapp</ApplicationId>
+    <RootNamespace>MyApp.Android</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Uno.WinUI" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AndroidResource Include="Resources\**\*" />
+    <None Include="Properties\AndroidManifest.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyApp\MyApp.csproj" />
+  </ItemGroup>
+</Project>

--- a/MyApp.Skia.Gtk/MyApp.Skia.Gtk.csproj
+++ b/MyApp.Skia.Gtk/MyApp.Skia.Gtk.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>MyApp.Skia.Gtk</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Uno.WinUI" Version="5.0.0" />
+    <PackageReference Include="Uno.WinUI.Skia.Gtk" Version="5.0.0" />
+    <PackageReference Include="GtkSharp" Version="3.24.24.110" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyApp\MyApp.csproj" />
+  </ItemGroup>
+</Project>

--- a/MyApp.Windows/MyApp.Windows.csproj
+++ b/MyApp.Windows/MyApp.Windows.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <RootNamespace>MyApp.Windows</RootNamespace>
+    <UseWinUI>true</UseWinUI>
+    <Nullable>enable</Nullable>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <WindowsPackageType>None</WindowsPackageType>
+    <Platforms>x86;x64;arm64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240802000" />
+    <PackageReference Include="Uno.WinUI" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" Exclude="bin\**;obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyApp\MyApp.csproj" />
+  </ItemGroup>
+</Project>

--- a/MyApp/MyApp.sln
+++ b/MyApp/MyApp.sln
@@ -4,6 +4,12 @@ VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyApp", "MyApp\\MyApp.csproj", "{510430F3-7571-4455-B5F2-C4E234097DB5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyApp.Windows", "..\\MyApp.Windows\\MyApp.Windows.csproj", "{7C094931-3954-44DC-823D-885F8090640E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyApp.Android", "..\\MyApp.Android\\MyApp.Android.csproj", "{D9324CE3-3482-422B-BEBD-A4802EB6DEFD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyApp.Skia.Gtk", "..\\MyApp.Skia.Gtk\\MyApp.Skia.Gtk.csproj", "{4F327DE1-4FB1-4FBC-9B14-093BB79B75E4}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -14,6 +20,18 @@ Global
         {510430F3-7571-4455-B5F2-C4E234097DB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {510430F3-7571-4455-B5F2-C4E234097DB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {510430F3-7571-4455-B5F2-C4E234097DB5}.Release|Any CPU.Build.0 = Release|Any CPU
+        {7C094931-3954-44DC-823D-885F8090640E}.Debug|Any CPU.ActiveCfg = Debug|x64
+        {7C094931-3954-44DC-823D-885F8090640E}.Debug|Any CPU.Build.0 = Debug|x64
+        {7C094931-3954-44DC-823D-885F8090640E}.Release|Any CPU.ActiveCfg = Release|x64
+        {7C094931-3954-44DC-823D-885F8090640E}.Release|Any CPU.Build.0 = Release|x64
+        {D9324CE3-3482-422B-BEBD-A4802EB6DEFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {D9324CE3-3482-422B-BEBD-A4802EB6DEFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {D9324CE3-3482-422B-BEBD-A4802EB6DEFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {D9324CE3-3482-422B-BEBD-A4802EB6DEFD}.Release|Any CPU.Build.0 = Release|Any CPU
+        {4F327DE1-4FB1-4FBC-9B14-093BB79B75E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {4F327DE1-4FB1-4FBC-9B14-093BB79B75E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {4F327DE1-4FB1-4FBC-9B14-093BB79B75E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {4F327DE1-4FB1-4FBC-9B14-093BB79B75E4}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -1,6 +1,6 @@
 # Hot Reload Workflow
 
-This guide explains how to run each MD-Editor head with XAML and C# Hot Reload so day-to-day UI work can happen without full rebuilds. The **primary development target** for Hot Reload is `MD-Editor.Windows` (WinUI). Android and Skia.Gtk heads are also covered below, along with their current limitations.
+This guide explains how to run each MyApp head with XAML and C# Hot Reload so day-to-day UI work can happen without full rebuilds. The **primary development target** for Hot Reload is `MyApp.Windows` (WinUI). Android and Skia.Gtk heads are also covered below, along with their current limitations.
 
 > **Prerequisites**
 >
@@ -10,10 +10,10 @@ This guide explains how to run each MD-Editor head with XAML and C# Hot Reload s
 
 ## 1. Enable Hot Reload in Visual Studio
 
-1. Open the solution and set **MD-Editor.Windows** as the startup project.
+1. Open the solution and set **MyApp.Windows** as the startup project.
 2. Navigate to **Tools ▸ Options ▸ Debugging ▸ Hot Reload**.
 3. Enable both **XAML Hot Reload** and **.NET/C# Hot Reload**.
-4. In the debug dropdown select **MD-Editor.Windows (Unpackaged)** or **MD-Editor.Windows (Packaged)** and ensure **Hot Reload on file save** is checked in the toolbar.
+4. In the debug dropdown select **MyApp.Windows (Unpackaged)** or **MyApp.Windows (Packaged)** and ensure **Hot Reload on file save** is checked in the toolbar.
 5. Start debugging (`F5`) or use **Hot Reload in Debugger** to launch once. Subsequent XAML edits in the shared project or the Windows head will apply immediately.
 
 ### Recommended Visual Studio workflow
@@ -27,7 +27,7 @@ This guide explains how to run each MD-Editor head with XAML and C# Hot Reload s
 For contributors working outside Visual Studio (for example on macOS or Linux) Hot Reload is available through `dotnet watch`.
 
 ```bash
-dotnet watch --project src/MD-Editor.Windows/MD-Editor.Windows.csproj --hot-reload --no-launch-profile
+dotnet watch --project MyApp.Windows/MyApp.Windows.csproj --hot-reload --no-launch-profile
 ```
 
 * The command builds the Windows head once, attaches the Hot Reload agent, and watches for XAML/C# changes.
@@ -45,24 +45,24 @@ dotnet watch --project src/MD-Editor.Windows/MD-Editor.Windows.csproj --hot-relo
 
 Record any issues in an engineering log or GitHub issue so we can track regressions.
 
-## 4. Android Head (`MD-Editor.Mobile`) Hot Reload
+## 4. Android Head (`MyApp.Android`) Hot Reload
 
 * Launch Visual Studio with the **Android** startup project or execute:
 
   ```bash
-  dotnet watch --project src/MD-Editor.Mobile/MD-Editor.Mobile.csproj --hot-reload --framework net8.0-android
+  dotnet watch --project MyApp.Android/MyApp.Android.csproj --hot-reload --framework net8.0-android
   ```
 
 * The Android tooling requires an emulator or device connected before running `dotnet watch`.
 * XAML Hot Reload supports most view changes; C# Hot Reload is limited while the app is running under the Mono runtime. Visual Studio will flag unsupported edits (for example method signature changes) and request a rebuild.
 * Expect the initial deployment to take longer because the application package must be deployed to the device. Once running, Hot Reload applies most UI tweaks without reinstalling.
 
-## 5. Skia.Gtk Head (`MD-Editor.Skia.Gtk`) Hot Reload
+## 5. Skia.Gtk Head (`MyApp.Skia.Gtk`) Hot Reload
 
 * Start the head via:
 
   ```bash
-  dotnet watch --project src/MD-Editor.Skia.Gtk/MD-Editor.Skia.Gtk.csproj --hot-reload --framework net8.0
+  dotnet watch --project MyApp.Skia.Gtk/MyApp.Skia.Gtk.csproj --hot-reload --framework net8.0
   ```
 
 * On Linux hosts ensure GTK 3 and WebKitGTK packages are installed. On macOS install them via Homebrew prior to running the command.
@@ -73,14 +73,14 @@ Record any issues in an engineering log or GitHub issue so we can track regressi
 
 * **Large refactors** (adding/removing `x:Name`, modifying resource dictionaries) may require a rebuild on all heads.
 * **Android**: When using `dotnet watch`, keep `adb logcat` open. If the app disconnects, stop and re-run the watch command so the Mono runtime reattaches Hot Reload.
-* **Skia.Gtk**: GTK windows launched via `dotnet watch` may stay resident after closing. Kill the process (`pkill -f MD-Editor.Skia.Gtk`) before starting a new session.
+* **Skia.Gtk**: GTK windows launched via `dotnet watch` may stay resident after closing. Kill the process (`pkill -f MyApp.Skia.Gtk`) before starting a new session.
 * **Primary target unavailable**: If you cannot run the Windows head locally (e.g., working from macOS), configure a Windows VM or Dev Box and forward your repo via source control syncing.
 
 ## 7. Capturing configuration for PRs
 
 When validating changes, record:
 
-* The head (`MD-Editor.Windows`, `MD-Editor.Mobile`, or `MD-Editor.Skia.Gtk`).
+* The head (`MyApp.Windows`, `MyApp.Android`, or `MyApp.Skia.Gtk`).
 * Command or launch profile used.
 * Whether Hot Reload succeeded for XAML and/or C# edits.
 * Any failures or required rebuilds.
@@ -90,7 +90,7 @@ Include these notes in pull request descriptions so reviewers can reproduce the 
 ## Appendix: IDE Checklist
 
 * ✔ Enable XAML + C# Hot Reload in Visual Studio options.
-* ✔ Confirm **MD-Editor.Windows** is set as the primary startup project.
+* ✔ Confirm **MyApp.Windows** is set as the primary startup project.
 * ✔ Verify `dotnet watch --hot-reload` is available (run `dotnet watch --version`).
 * ✔ Keep diagnostics windows open (Hot Reload output, Live Visual Tree, Android Device Log).
 


### PR DESCRIPTION
## Summary
- restore the Windows, Android, and Skia.Gtk head project files with Uno/WinUI target frameworks and shared project references
- add the three head projects to `MyApp.sln` so IDEs and the CLI can discover them
- refresh hot reload documentation so commands reference the restored head project names and paths

## Testing
- dotnet restore *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d7191c608331a52fc44a863bdc2f