### PR TITLE
fix: add platform head projects to solution

### DIFF
--- a/MyApp.Android/MyApp.Android.csproj
+++ b/MyApp.Android/MyApp.Android.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-android</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ApplicationId>com.myapp.editor</ApplicationId>
+    <ApplicationVersion>1</ApplicationVersion>
+    <SupportedOSPlatformVersion>24</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AndroidManifest Include="Properties\AndroidManifest.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyApp\MyApp\MyApp.csproj" />
+  </ItemGroup>
+</Project>

--- a/MyApp.Skia.Gtk/MyApp.Skia.Gtk.csproj
+++ b/MyApp.Skia.Gtk/MyApp.Skia.Gtk.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GtkSharp" Version="3.24.24.52" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyApp\MyApp\MyApp.csproj" />
+  </ItemGroup>
+</Project>

--- a/MyApp.Windows/App.xaml.cs
+++ b/MyApp.Windows/App.xaml.cs
@@ -5,7 +5,7 @@ using MyApp.Windows.Services;
 
 namespace MyApp.Windows;
 
-public partial class App : Application
+public class App : Application
 {
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {

--- a/MyApp.Windows/MyApp.Windows.csproj
+++ b/MyApp.Windows/MyApp.Windows.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWinUI>true</UseWinUI>
+    <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240404000" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyApp\MyApp\MyApp.csproj" />
+  </ItemGroup>
+</Project>

--- a/MyApp.Windows/Program.cs
+++ b/MyApp.Windows/Program.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.UI.Xaml;
+
+namespace MyApp.Windows;
+
+public static class Program
+{
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        Application.Start(_ => new App());
+    }
+}

--- a/MyApp/MyApp.sln
+++ b/MyApp/MyApp.sln
@@ -4,17 +4,35 @@ VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyApp", "MyApp\MyApp.csproj", "{510430F3-7571-4455-B5F2-C4E234097DB5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyApp.Windows", "..\MyApp.Windows\MyApp.Windows.csproj", "{8E49830D-F401-44D8-9DEC-565A7594365B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyApp.Android", "..\MyApp.Android\MyApp.Android.csproj", "{1A5872D4-D3C7-46C1-9D1D-ACA76781CA61}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyApp.Skia.Gtk", "..\MyApp.Skia.Gtk\MyApp.Skia.Gtk.csproj", "{6783794D-46CA-4E4F-920A-5D6DD07D2E02}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{510430F3-7571-4455-B5F2-C4E234097DB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{510430F3-7571-4455-B5F2-C4E234097DB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{510430F3-7571-4455-B5F2-C4E234097DB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{510430F3-7571-4455-B5F2-C4E234097DB5}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {510430F3-7571-4455-B5F2-C4E234097DB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {510430F3-7571-4455-B5F2-C4E234097DB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {510430F3-7571-4455-B5F2-C4E234097DB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {510430F3-7571-4455-B5F2-C4E234097DB5}.Release|Any CPU.Build.0 = Release|Any CPU
+                {8E49830D-F401-44D8-9DEC-565A7594365B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8E49830D-F401-44D8-9DEC-565A7594365B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {8E49830D-F401-44D8-9DEC-565A7594365B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {8E49830D-F401-44D8-9DEC-565A7594365B}.Release|Any CPU.Build.0 = Release|Any CPU
+                {1A5872D4-D3C7-46C1-9D1D-ACA76781CA61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1A5872D4-D3C7-46C1-9D1D-ACA76781CA61}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {1A5872D4-D3C7-46C1-9D1D-ACA76781CA61}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1A5872D4-D3C7-46C1-9D1D-ACA76781CA61}.Release|Any CPU.Build.0 = Release|Any CPU
+                {6783794D-46CA-4E4F-920A-5D6DD07D2E02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {6783794D-46CA-4E4F-920A-5D6DD07D2E02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {6783794D-46CA-4E4F-920A-5D6DD07D2E02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {6783794D-46CA-4E4F-920A-5D6DD07D2E02}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -2,14 +2,29 @@
 
 A lightweight markdown editing experience focused on speed and simplicity.
 
-## Usage
+## Quick start
 
-1. This.
-2. Is.
-3. Empty.
-4. For.
-5. Now
+```bash
+dotnet restore MyApp/MyApp.sln
+dotnet build MyApp/MyApp.sln
+```
 
+After the solution builds, Visual Studio will list four projects in **Solution Explorer**:
+
+* **MyApp** – the shared class library.
+* **MyApp.Windows** – WinUI 3 desktop head (default debugging target).
+* **MyApp.Android** – native Android head.
+* **MyApp.Skia.Gtk** – cross-platform GTK desktop head.
+
+Set one of the head projects as the startup project before debugging. Then launch it using the table below:
+
+| Platform | Launch command | Expected result |
+| --- | --- | --- |
+| Windows | Start **MyApp.Windows (Unpackaged)** from Visual Studio or run `dotnet run --project MyApp.Windows/MyApp.Windows.csproj` from an elevated Windows shell. | A 1024×768 window titled **MyApp** opens with a command bar containing **New**, **Open**, and **Save** buttons. Clicking any button writes `"<Command> document requested"` to the debug/output console. |
+| Linux/macOS | `dotnet run --project MyApp.Skia.Gtk/MyApp.Skia.Gtk.csproj` | A GTK window titled **MyApp** appears with a **File** menu that contains **New**, **Open**, **Save**, and **Exit**. Choosing a menu item prints `"<Command> document requested"` to the terminal running the app. |
+| Android | Deploy **MyApp.Android** from Visual Studio or run `dotnet build MyApp.Android/MyApp.Android.csproj -t:Run -f net8.0-android`. | The emulator/device launches a simple screen ready for further UI work. |
+
+The shared project (`MyApp/MyApp.csproj`) is a class library. Starting it directly results in the standard Visual Studio message **"A project with an Output Type of Class Library cannot be started directly"**. Always run one of the platform heads instead.
 
 ## Configuration
 
@@ -21,7 +36,9 @@ Additional modes or advanced workflows have not been supplied by the user.
 
 ## Troubleshooting & FAQ
 
-No user-provided troubleshooting tips or frequently asked questions are available yet.
+### Visual Studio reports that the project cannot be started
+
+This warning appears when the shared project is selected as the startup project. In **Solution Explorer**, right-click **MyApp.Windows** (for desktop) or another head project and choose **Set as StartUp Project**. The next debug run will launch the corresponding app window described above.
 
 ### Hot Reload Workflow
 


### PR DESCRIPTION
## Summary
- add WinUI, Android, and GTK head projects to the MyApp solution
- wire up the Windows entry point so the WinUI head can launch
- update the quick start instructions to explain the newly listed projects

## Testing
- not run (toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e33dbbfe1c833183dce17266cfef1e